### PR TITLE
fix argument parsing for termux

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@ static void cleanExit(int signal)
 
 int main(int argc, char *argv[])
 {
-	char argOpt;
+	signed char argOpt;
 	long startEpochMs = 0, timerMs = 0;
 	flag_t mainFlags = FLAG_MAIN_NONE;
 	input_t input;


### PR DESCRIPTION
from what i've seen on GDB, getopt does seems to return -1, but on unsigned form (255). this makes it impossible to start the game on termux.

changing the type of argOpt from `char` to `signed char` seems to fix this issue...